### PR TITLE
Change text in Tab One to 'Hello ICU!'

### DIFF
--- a/hello-expo-app/app/(tabs)/index.tsx
+++ b/hello-expo-app/app/(tabs)/index.tsx
@@ -6,7 +6,7 @@ import { Text, View } from '@/components/Themed';
 export default function TabOneScreen() {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Tab One</Text>
+      <Text style={styles.title}>Hello ICU !</Text>
       <View style={styles.separator} lightColor="#eee" darkColor="rgba(255,255,255,0.1)" />
       <EditScreenInfo path="app/(tabs)/index.tsx" />
     </View>


### PR DESCRIPTION
### Description

This pull request updates the text in `Tab One` to display `Hello ICU!`. This fixes a minor issue to align the text content with the intended message.