### PR TITLE
Set up basic Quiz UI and layout structure

### DIFF
--- a/hello-expo-app/.gitignore
+++ b/hello-expo-app/.gitignore
@@ -35,3 +35,5 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+.idea

--- a/hello-expo-app/app/(tabs)/_layout.tsx
+++ b/hello-expo-app/app/(tabs)/_layout.tsx
@@ -30,7 +30,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          title: 'Tab One',
+          title: 'Tab test',
           tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
           headerRight: () => (
             <Link href="/modal" asChild>

--- a/hello-expo-app/app/quiz/_layout.tsx
+++ b/hello-expo-app/app/quiz/_layout.tsx
@@ -1,0 +1,10 @@
+// app/quiz/_layout.tsx
+import { Stack } from 'expo-router';
+
+/**
+ * quiz 以下の画面共通レイアウト
+ * いったんヘッダ非表示のみ
+ */
+export default function QuizLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/hello-expo-app/app/quiz/index.tsx
+++ b/hello-expo-app/app/quiz/index.tsx
@@ -1,0 +1,46 @@
+// app/quiz/index.tsx
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import QuestionCard from '@/components/QuestionCard'; // tsconfig の paths 設定済なら @ で
+
+export default function QuizScreen() {
+  const [score, setScore] = useState(0); // まだ固定値
+
+  const handleNext = () => {
+    // ★ダミーでスコア +1（lint 対策）
+    setScore((prev) => prev + 1);
+
+    // TODO: 質問を次に切り替える処理を後で実装
+  };
+
+  return (
+    <View style={styles.container}>
+      <QuestionCard />
+
+      <View style={styles.footer}>
+        <Text style={styles.score}>Score: {score}</Text>
+        <Pressable style={styles.nextBtn} onPress={handleNext}>
+          <Text style={styles.nextLabel}>Next</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  footer: {
+    marginTop: 'auto',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  score: { fontSize: 18, fontWeight: 'bold' },
+  nextBtn: {
+    backgroundColor: '#4f46e5',
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 24,
+  },
+  nextLabel: { color: '#fff', fontSize: 16, fontWeight: 'bold' },
+});

--- a/hello-expo-app/components/QuestionCard.tsx
+++ b/hello-expo-app/components/QuestionCard.tsx
@@ -1,0 +1,34 @@
+// components/QuestionCard.tsx
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function QuestionCard() {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Question — ダミー</Text>
+      {['A', 'B', 'C', 'D'].map((l) => (
+        <View key={l} style={styles.option}>
+          <Text>
+            {l}. Option {l}
+          </Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    marginVertical: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 4,
+    elevation: 3, // Android
+  },
+  title: { fontSize: 16, fontWeight: 'bold', marginBottom: 12 },
+  option: { paddingVertical: 6 },
+});


### PR DESCRIPTION
### Description

This pull request implements the foundational UI and layout for the Quiz screen to streamline future feature expansion. 

**Key changes include:**
- Created `components/QuestionCard.tsx` for displaying quiz questions.
- Added a shared layout for the Quiz screen (`app/quiz/_layout.tsx`) and hid the header.
- Updated `app/(tabs)/_layout.tsx`, temporarily renaming the Tab display to "Tab test".
- Built the Quiz screen (`app/quiz/index.tsx`) featuring score display and a "Next" button for progression.
- Initialized layout for Quiz functionality by adding `hello-expo-app/app/quiz/_layout.tsx`.
- Updated `.gitignore` to exclude `.idea` files.

### Checklist

- [ ] Tests added/updated when applicable
- [ ] Documentation updated where necessary
- [ ] Code formatted with proper linting tools